### PR TITLE
Highlight Perl code in syntax highlighter

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -205,7 +205,7 @@ const config: Config = {
     },
 
     prism: {
-      additionalLanguages: ['java'],
+      additionalLanguages: ['perl', 'java'],
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
     },


### PR DESCRIPTION
Add Perl to the list of additional languages for syntax highlighting.